### PR TITLE
changes to the parameters of quart dimensions from scripts

### DIFF
--- a/macros/batchSubmission.py
+++ b/macros/batchSubmission.py
@@ -46,11 +46,11 @@ LightGuideLowerInterface = list(map(str, np.random.uniform(2,100,size=1+int(x[in
 LightGuideUpperInterface = list(map(str, np.random.uniform(500,700,size=1+int(x[index:])-int(x[:index-1]))))
 LightGuidePMTInterfaceOpeningX = list(map(str, np.random.uniform(50,90, size=1+int(x[index:])-int(x[:index-1]))))
 LightGuidePMTInterfaceOpeningZ = list(map(str, np.random.uniform(50,90, size=1+int(x[index:])-int(x[:index-1]))))
-LightGuideQuartzInterfaceOpeningX = list(map(str, np.random.uniform(20,200, size=1+int(x[index:])-int(x[:index-1]))))
-LightGuideQuartzInterfaceOpeningZ = list(map(str, np.random.uniform(20,200, size=1+int(x[index:])-int(x[:index-1]))))
-QuartzSizeZ = list(map(str, np.random.uniform(5,25,size=1+int(x[index:])-int(x[:index-1]))))
-QuartzSizeX = list(map(str, np.random.uniform(120,220,size=1+int(x[index:])-int(x[:index-1]))))
-QuartzSizeY = list(map(str, np.random.uniform(55,65,size=1+int(x[index:])-int(x[:index-1]))))
+QuartzSizeZ = list(map(str, np.random.uniform(10,30,size=1+int(x[index:])-int(x[:index-1]))))
+QuartzSizeX = list(map(str, np.random.uniform(153,167,size=1+int(x[index:])-int(x[:index-1]))))
+QuartzSizeY = list(map(str, np.random.uniform(59,61,size=1+int(x[index:])-int(x[:index-1]))))
+LightGuideQuartzInterfaceOpeningX = QuartzSizeX + 8
+LightGuideQuartzInterfaceOpeningZ = QuartzSizeZ + 7
 QuartzBevelSize = list(map(str, np.random.uniform(0.05,0.11,size=(1+int(x[index:])-int(x[:index-1])))))
 QuartzRotX = list(map(str, np.random.uniform(-3,3,size=(1+int(x[index:])-int(x[:index-1])))))
 PolarRotation = list(map(str, np.random.uniform(-3,3,size=(1+int(x[index:])-int(x[:index-1])))))


### PR DESCRIPTION
We are choosing a range around 20 mm for quartz size z. We can look at the effect on detector resolution. And the width of quartz, quartz size x was estimated from the document : https://moller.jlab.org/DocDB/0007/000769/003/210817_MDtiling_CGal.pdf,slide 11, we got the radius of the rings,maximum and minimum and calculated the maximum and minimum circumference and then estimated the rings minimum and maximum width by dividing the circumference by the number of modules. If we choose the minimum width then there will be gaps in the design and if we take the maximum then we need to consider double counting. From the document : https://github.com/mtgericke/MOLLER-IntDetectorOpticalSim/blob/main/GREXMakeScanMacros.py we got the estimated value of quartz interface opening x and z and set it to (quartz size X + 8 and quartz size Z + 7).